### PR TITLE
Fix: threaded-replies getting instantly deleted after a message is "Sent to Channel"

### DIFF
--- a/interactions/cleanupChannel.js
+++ b/interactions/cleanupChannel.js
@@ -39,7 +39,7 @@ async function cleanupChannel(args) {
             });
             
             // const isThreadBroadcast = threadMessage.messages.some(msg => msg.subtype === 'thread_broadcast');
-            const isThreadBroadcast = payload.subtype === 'thread_broadcast'; // check the current msg
+            const isThreadBroadcast = subtype === 'thread_broadcast'; // check the current msg
 
 
             if (isThreadBroadcast) {

--- a/interactions/cleanupChannel.js
+++ b/interactions/cleanupChannel.js
@@ -38,7 +38,9 @@ async function cleanupChannel(args) {
                 ts: thread_ts,
             });
             
-            const isThreadBroadcast = threadMessage.messages.some(msg => msg.subtype === 'thread_broadcast');
+            // const isThreadBroadcast = threadMessage.messages.some(msg => msg.subtype === 'thread_broadcast');
+            const isThreadBroadcast = payload.subtype === 'thread_broadcast'; // check the current msg
+
 
             if (isThreadBroadcast) {
                 await client.chat.delete({


### PR DESCRIPTION
The code-snipped checked if ANY of the messages were sent to channel and deletes the current message if that was true.


**Scenario**: An admin sends a message to a Channel (subtype = "thread_broadcast") and then other users replied in that thread, this would cause those messages to get deleted.

**Fix**: Rather than checking if ANY messages were sent to channel, check if the current message was sent to channel or not.

**To replicate**: Go to a read-only channel, send a message as an Admin, reply in the thread and send reply to channel. Any non-admin replies would be instantly deleted.


https://github.com/user-attachments/assets/c2b0b030-c417-42ac-a4ee-87800eb5787b



