### PR TITLE
Banned > shushed for MIRROR_CHANNEL updates

### DIFF
--- a/commands/shush.js
+++ b/commands/shush.js
@@ -30,7 +30,7 @@ async function shushBan(args) {
     if (isAdmin) {
       await client.chat.postMessage({
         channel: process.env.MIRRORCHANNEL,
-        text: `<@${user_id}> banned <@${userToBan}> from all Slack channels. ${reason ? `for ${reason}` : ""}`,
+        text: `<@${user_id}> shushed <@${userToBan}> from all Slack channels. ${reason ? `for ${reason}` : ""}`,
       });
     }
 
@@ -62,7 +62,7 @@ async function shushBan(args) {
       await client.chat.postEphemeral({
         channel: channel_id,
         user: user_id,
-        text: `<@${userToBan}> has been banned from all channels for ${reason}`,
+        text: `<@${userToBan}> has been shushed from all channels for ${reason}`,
         mrkdwn: true,
       });
     }


### PR DESCRIPTION
The wording is a bit confusing when we get a mesage saying that someone's been banned from all channels, but in actuality, they've been 'shushed'.

This PR updates the admin facing messages only - saying 'shushed' may be unclear for the end user, but the FD know what it's on about!